### PR TITLE
Adding a .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: php
+php:
+    - 5.5
+    - 5.6
+    - nightly
+
+cache:
+    directories:
+        - vendor
+        - $HOME/.composer/cache
+
+install:
+    - composer self-update
+    - composer install
+    
+before_script:
+    - php artisan key:generate
+    - php artisan migrate
+    - php vendor/codeception/codeception/codecept build
+
+script: php vendor/codeception/codeception/codecept run
+


### PR DESCRIPTION
This file will allow our `Codeception` tests to run on [Travis](http://travis-ci.org)
